### PR TITLE
Closes #7

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,11 +12,17 @@ Fork_, then clone the repo:
 
 Open ``DispatchKit.xcodeproj`` in Xcode. Make sure the tests pass.
 
+Please, setup your Xcode to strip trailing whitespace,
+`including whitespace-only lines <http://stackoverflow.com/a/11830067/2958047>`_.
+Use `<Tools/strip-trailing-whitespace>`_ script to strip trailing whitespace from existing files.
+
 Make your change. Follow the style of the surrounding code.
 
 Add tests for your change. Make the tests pass.
 
-Commit your change. Write a `good commit message`_.
+Commit your change. Write a `good commit message`_,
+describing the essence of your work on the first line,
+optionally providing additional explanations on subsequent lines.
 
 Push to your fork and `submit a pull request`_.
 
@@ -24,4 +30,4 @@ Wait for review. Note I may suggest some changes or improvements or alternatives
 
 .. _fork: https://github.com/anpol/DispatchKit/fork
 .. _submit a pull request: https://github.com/anpol/DispatchKit/compare/
-.. _good commit message: https://atom.io/docs/latest/contributing#git-commit-messages
+.. _good commit message: https://github.com/atom/atom/blob/master/CONTRIBUTING.md#git-commit-messages

--- a/Examples/CheatSheet.swift
+++ b/Examples/CheatSheet.swift
@@ -42,7 +42,7 @@ func cheatQueues() {
     concurrentQueue.apply(42) { i in
         print("item #\(i)")
     }
-    
+
     Dispatch.globalQueue.async {
         // async task
     }

--- a/Sources/Dispatch.swift
+++ b/Sources/Dispatch.swift
@@ -14,7 +14,7 @@ public struct Dispatch {
     }
 
     public static var mainQueue: DispatchQueue {
-        return DispatchQueue(raw: dispatch_get_main_queue())
+        return DispatchQueue(rawValue: dispatch_get_main_queue())
     }
 
     public static var globalQueue: DispatchQueue {
@@ -22,7 +22,7 @@ public struct Dispatch {
     }
 
     public static func getGlobalQueue(priority priority: DispatchQueuePriority, flags: Int = 0) -> DispatchQueue {
-        return DispatchQueue(raw: dispatch_get_global_queue(priority.rawValue, UInt(flags)))
+        return DispatchQueue(rawValue: dispatch_get_global_queue(priority.rawValue, UInt(flags)))
     }
 
     public static func getGlobalQueue(qosClass qosClass: DispatchQOSClass, flags: Int = 0) -> DispatchQueue {
@@ -33,7 +33,7 @@ public struct Dispatch {
             identifier = DispatchQueuePriority(qosClass: qosClass).rawValue
         }
 
-        return DispatchQueue(raw: dispatch_get_global_queue(identifier, UInt(flags)))
+        return DispatchQueue(rawValue: dispatch_get_global_queue(identifier, UInt(flags)))
     }
 
 }

--- a/Sources/DispatchData.swift
+++ b/Sources/DispatchData.swift
@@ -39,7 +39,7 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
     public init!(_ array: [T]) {
         let size = Scale.toBytes(array.count)
 
-        guard let rawValue = array.withUnsafeBufferPointer({ (p) in
+        guard let rawValue = array.withUnsafeBufferPointer({ p in
             dispatch_data_create(p.baseAddress, size, nil, nil)
         }) else {
             return nil

--- a/Sources/DispatchData.swift
+++ b/Sources/DispatchData.swift
@@ -9,7 +9,6 @@ import Foundation
 
 public struct DispatchData<T: IntegerType>: DispatchObject {
 
-    public typealias RawValue = dispatch_data_t
     typealias Scale = DispatchDataScale<T>
 
     public static var Empty: DispatchData {
@@ -17,18 +16,18 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
     }
 
     @available(*, unavailable, renamed="rawValue")
-    public var data: RawValue {
+    public var data: dispatch_data_t {
         return rawValue
     }
 
-    public let rawValue: RawValue
+    public let rawValue: dispatch_data_t
 
     @available(*, unavailable, renamed="DispatchData(rawValue:)")
-    public init(raw data: RawValue) {
+    public init(raw data: dispatch_data_t) {
         self.rawValue = data
     }
 
-    public init(rawValue: RawValue) {
+    public init(rawValue: dispatch_data_t) {
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchData.swift
+++ b/Sources/DispatchData.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 public struct DispatchData<T: IntegerType>: DispatchObject {
-    
+
     public typealias RawValue = dispatch_data_t
     typealias Scale = DispatchDataScale<T>
 
     public static var Empty: DispatchData {
         return DispatchData(rawValue: dispatch_data_empty)
     }
-    
+
     @available(*, unavailable, renamed="rawValue")
     public var data: RawValue {
         return rawValue
@@ -27,7 +27,7 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
     public init(raw data: RawValue) {
         self.rawValue = data
     }
-    
+
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
@@ -39,13 +39,13 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
      */
     public init!(_ array: [T]) {
         let size = Scale.toBytes(array.count)
-        
+
         guard let rawValue = array.withUnsafeBufferPointer({ (p) in
             dispatch_data_create(p.baseAddress, size, nil, nil)
         }) else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 
@@ -58,13 +58,13 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
      */
     public init!(_ buffer: UnsafeMutablePointer<T>, _ count: Int, _ queue: dispatch_queue_t! = nil) {
         let size = Scale.toBytes(count)
-        
+
         guard let rawValue = dispatch_data_create(buffer, size, queue, {
             buffer.dealloc(count)
         }) else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 
@@ -76,7 +76,7 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
         guard let rawValue = dispatch_data_create(buffer, size, queue, destructor) else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 
@@ -87,11 +87,11 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
     public subscript(range: Range<Int>) -> DispatchData! {
         let offset = Scale.toBytes(range.startIndex)
         let length = Scale.toBytes(range.endIndex - range.startIndex)
-        
+
         guard let rawValue = dispatch_data_create_subrange(rawValue, offset, length) else {
             return nil
         }
-        
+
         return DispatchData(rawValue: rawValue)
     }
 
@@ -100,11 +100,11 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
 
     public func copyRegion(location: Int) -> Region! {
         var offset: Int = 0
-        
+
         guard let region = dispatch_data_copy_region(rawValue, Scale.toBytes(location), &offset) else {
             return nil
         }
-        
+
         return (DispatchData(rawValue: region), Scale.fromBytes(offset))
     }
 
@@ -114,11 +114,11 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
     public func createMap() -> (owner: DispatchData, buffer: Buffer)! {
         var buffer: UnsafePointer<Void> = nil
         var size: Int = 0
-        
+
         guard let owner = dispatch_data_create_map(rawValue, &buffer, &size) else {
             return nil
         }
-        
+
         return (DispatchData(rawValue: owner), (UnsafePointer<T>(buffer), Scale.fromBytes(size)))
     }
 
@@ -140,6 +140,6 @@ public func + <T>(a: DispatchData<T>, b: DispatchData<T>) -> DispatchData<T>? {
     guard let rawValue = dispatch_data_create_concat(a.rawValue, b.rawValue) else {
         return nil
     }
-    
+
     return DispatchData<T>(rawValue: rawValue)
 }

--- a/Sources/DispatchData.swift
+++ b/Sources/DispatchData.swift
@@ -20,12 +20,12 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
         return rawValue
     }
 
-    public let rawValue: dispatch_data_t
-
     @available(*, unavailable, renamed="DispatchData(rawValue:)")
     public init(raw data: dispatch_data_t) {
         self.rawValue = data
     }
+
+    public let rawValue: dispatch_data_t
 
     public init(rawValue: dispatch_data_t) {
         self.rawValue = rawValue

--- a/Sources/DispatchData.swift
+++ b/Sources/DispatchData.swift
@@ -8,21 +8,28 @@
 import Foundation
 
 public struct DispatchData<T: IntegerType>: DispatchObject {
-
+    
+    public typealias RawValue = dispatch_data_t
     typealias Scale = DispatchDataScale<T>
 
     public static var Empty: DispatchData {
-        return DispatchData(raw: dispatch_data_empty)
+        return DispatchData(rawValue: dispatch_data_empty)
+    }
+    
+    @available(*, unavailable, renamed="rawValue")
+    public var data: RawValue {
+        return rawValue
     }
 
-    public let data: dispatch_data_t!
+    public let rawValue: RawValue
 
-    public var rawValue: dispatch_object_t! {
-        return data
+    @available(*, unavailable, renamed="DispatchData(rawValue:)")
+    public init(raw data: RawValue) {
+        self.rawValue = data
     }
-
-    public init(raw data: dispatch_data_t!) {
-        self.data = data
+    
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
     }
 
     /**
@@ -30,11 +37,16 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
      *
      * - parameter array: The array to be copied.
      */
-    public init(_ array: [T]) {
+    public init!(_ array: [T]) {
         let size = Scale.toBytes(array.count)
-        self.data = array.withUnsafeBufferPointer { (p) in
+        
+        guard let rawValue = array.withUnsafeBufferPointer({ (p) in
             dispatch_data_create(p.baseAddress, size, nil, nil)
+        }) else {
+            return nil
         }
+        
+        self.rawValue = rawValue
     }
 
     /**
@@ -44,57 +56,79 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
      * - parameter count:
      * - parameter queue: A queue on which to call `UnsafeMutablePointer.dealloc`_ for the buffer.
      */
-    public init(_ buffer: UnsafeMutablePointer<T>, _ count: Int, _ queue: dispatch_queue_t! = nil) {
+    public init!(_ buffer: UnsafeMutablePointer<T>, _ count: Int, _ queue: dispatch_queue_t! = nil) {
         let size = Scale.toBytes(count)
-        self.data = dispatch_data_create(buffer, size, queue) {
+        
+        guard let rawValue = dispatch_data_create(buffer, size, queue, {
             buffer.dealloc(count)
+        }) else {
+            return nil
         }
+        
+        self.rawValue = rawValue
     }
 
     // The destructor is responsible to free the buffer.
-    public init(_ buffer: UnsafePointer<T>, _ count: Int,
+    public init!(_ buffer: UnsafePointer<T>, _ count: Int,
          _ queue: dispatch_queue_t!, destructor: dispatch_block_t!) {
 
         let size = Scale.toBytes(count)
-        self.data = dispatch_data_create(buffer, size, queue, destructor)
+        guard let rawValue = dispatch_data_create(buffer, size, queue, destructor) else {
+            return nil
+        }
+        
+        self.rawValue = rawValue
     }
 
     public var count: Int {
-        return Scale.fromBytes(dispatch_data_get_size(data))
+        return Scale.fromBytes(dispatch_data_get_size(rawValue))
     }
 
-    public subscript(range: Range<Int>) -> DispatchData {
+    public subscript(range: Range<Int>) -> DispatchData! {
         let offset = Scale.toBytes(range.startIndex)
         let length = Scale.toBytes(range.endIndex - range.startIndex)
-        return DispatchData(raw: dispatch_data_create_subrange(data, offset, length))
+        
+        guard let rawValue = dispatch_data_create_subrange(rawValue, offset, length) else {
+            return nil
+        }
+        
+        return DispatchData(rawValue: rawValue)
     }
 
 
     public typealias Region = (data: DispatchData, offset: Int)
 
-    public func copyRegion(location: Int) -> Region {
+    public func copyRegion(location: Int) -> Region! {
         var offset: Int = 0
-        let region = dispatch_data_copy_region(data, Scale.toBytes(location), &offset)
-        return (DispatchData(raw: region), Scale.fromBytes(offset))
+        
+        guard let region = dispatch_data_copy_region(rawValue, Scale.toBytes(location), &offset) else {
+            return nil
+        }
+        
+        return (DispatchData(rawValue: region), Scale.fromBytes(offset))
     }
 
 
     public typealias Buffer = (start: UnsafePointer<T>, count: Int)
 
-    public func createMap() -> (owner: dispatch_data_t!, buffer: Buffer) {
+    public func createMap() -> (owner: DispatchData, buffer: Buffer)! {
         var buffer: UnsafePointer<Void> = nil
         var size: Int = 0
-        let owner = dispatch_data_create_map(data, &buffer, &size)
-        return (owner, (UnsafePointer<T>(buffer), Scale.fromBytes(size)))
+        
+        guard let owner = dispatch_data_create_map(rawValue, &buffer, &size) else {
+            return nil
+        }
+        
+        return (DispatchData(rawValue: owner), (UnsafePointer<T>(buffer), Scale.fromBytes(size)))
     }
 
 
     public typealias Applier = (region: Region, buffer: Buffer) -> Bool
 
     public func apply(applier: Applier) -> Bool {
-        return dispatch_data_apply(data) {
+        return dispatch_data_apply(rawValue) {
             (region, offset, buffer, size) -> Bool in
-            applier(region: (DispatchData<T>(raw: region), Scale.fromBytes(offset)),
+            applier(region: (DispatchData<T>(rawValue: region), Scale.fromBytes(offset)),
                     buffer: (UnsafePointer<T>(buffer), Scale.fromBytes(size)))
         }
     }
@@ -102,6 +136,10 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
 }
 
 
-public func + <T>(a: DispatchData<T>, b: DispatchData<T>) -> DispatchData<T> {
-    return DispatchData<T>(raw: dispatch_data_create_concat(a.data, b.data))
+public func + <T>(a: DispatchData<T>, b: DispatchData<T>) -> DispatchData<T>? {
+    guard let rawValue = dispatch_data_create_concat(a.rawValue, b.rawValue) else {
+        return nil
+    }
+    
+    return DispatchData<T>(rawValue: rawValue)
 }

--- a/Sources/DispatchData.swift
+++ b/Sources/DispatchData.swift
@@ -135,7 +135,7 @@ public struct DispatchData<T: IntegerType>: DispatchObject {
 }
 
 
-public func + <T>(a: DispatchData<T>, b: DispatchData<T>) -> DispatchData<T>? {
+public func + <T>(a: DispatchData<T>, b: DispatchData<T>) -> DispatchData<T>! {
     guard let rawValue = dispatch_data_create_concat(a.rawValue, b.rawValue) else {
         return nil
     }

--- a/Sources/DispatchGroup.swift
+++ b/Sources/DispatchGroup.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable {
-    
+
     public typealias RawValue = dispatch_group_t
-    
+
     @available(*, unavailable, renamed="rawValue")
     public var group: RawValue {
         return rawValue
@@ -22,7 +22,7 @@ public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable
     public init(raw group: RawValue) {
         self.rawValue = group
     }
-    
+
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
@@ -31,7 +31,7 @@ public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable
         guard let rawValue = dispatch_group_create() else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchGroup.swift
+++ b/Sources/DispatchGroup.swift
@@ -8,28 +8,40 @@
 import Foundation
 
 public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable {
-
-    public let group: dispatch_group_t!
-
-    public var rawValue: dispatch_object_t! {
-        return group
+    
+    public typealias RawValue = dispatch_group_t
+    
+    @available(*, unavailable, renamed="rawValue")
+    public var group: RawValue {
+        return rawValue
     }
 
-    public init(raw group: dispatch_group_t!) {
-        self.group = group
+    public let rawValue: RawValue
+
+    @available(*, unavailable, renamed="DispatchGroup(rawValue:)")
+    public init(raw group: RawValue) {
+        self.rawValue = group
+    }
+    
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
     }
 
-    public init() {
-        self.group = dispatch_group_create()
+    public init!() {
+        guard let rawValue = dispatch_group_create() else {
+            return nil
+        }
+        
+        self.rawValue = rawValue
     }
 
 
     public func enter() {
-        dispatch_group_enter(group)
+        dispatch_group_enter(rawValue)
     }
 
     public func leave() {
-        dispatch_group_leave(group)
+        dispatch_group_leave(rawValue)
     }
 
 
@@ -39,11 +51,11 @@ public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable
     }
 
     public func wait(timeout: DispatchTime) -> Int {
-        return dispatch_group_wait(group, timeout.rawValue)
+        return dispatch_group_wait(rawValue, timeout.rawValue)
     }
 
     public func notify(queue: DispatchQueue, block: dispatch_block_t) {
-        dispatch_group_notify(group, queue.queue, block)
+        dispatch_group_notify(rawValue, queue.rawValue, block)
     }
 
 

--- a/Sources/DispatchGroup.swift
+++ b/Sources/DispatchGroup.swift
@@ -9,21 +9,19 @@ import Foundation
 
 public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable {
 
-    public typealias RawValue = dispatch_group_t
-
     @available(*, unavailable, renamed="rawValue")
-    public var group: RawValue {
+    public var group: dispatch_group_t {
         return rawValue
     }
 
-    public let rawValue: RawValue
+    public let rawValue: dispatch_group_t
 
     @available(*, unavailable, renamed="DispatchGroup(rawValue:)")
-    public init(raw group: RawValue) {
+    public init(raw group: dispatch_group_t) {
         self.rawValue = group
     }
 
-    public init(rawValue: RawValue) {
+    public init(rawValue: dispatch_group_t) {
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchGroup.swift
+++ b/Sources/DispatchGroup.swift
@@ -14,12 +14,12 @@ public struct DispatchGroup: DispatchObject, DispatchEnterable, DispatchWaitable
         return rawValue
     }
 
-    public let rawValue: dispatch_group_t
-
     @available(*, unavailable, renamed="DispatchGroup(rawValue:)")
     public init(raw group: dispatch_group_t) {
         self.rawValue = group
     }
+
+    public let rawValue: dispatch_group_t
 
     public init(rawValue: dispatch_group_t) {
         self.rawValue = rawValue

--- a/Sources/DispatchIO.swift
+++ b/Sources/DispatchIO.swift
@@ -10,19 +10,19 @@ import Foundation
 public struct DispatchIO: DispatchObject {
 
     public typealias RawValue = dispatch_io_t
-    
+
     @available(*, unavailable, renamed="rawValue")
     public var io: RawValue {
         return rawValue
     }
-    
+
     public let rawValue: RawValue
 
     @available(*, unavailable, renamed="DispatchIO(rawValue:)")
     public init(raw io: RawValue) {
         self.rawValue = io
     }
-    
+
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
@@ -36,14 +36,14 @@ public struct DispatchIO: DispatchObject {
         guard let rawValue = dispatch_io_create(type.rawValue, fd, queue?.rawValue, cleanup) else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 
     public init!(_ type: DispatchIOType,
          path: String, oflag: CInt = O_RDONLY, mode: mode_t = 0o644,
          queue: DispatchQueue? = nil, cleanup: CleanupHandler! = nil) {
-        
+
         guard let rawValue = dispatch_io_create_with_path(type.rawValue, path, oflag, mode, queue?.rawValue, cleanup) else {
             return nil
         }
@@ -54,7 +54,7 @@ public struct DispatchIO: DispatchObject {
     public init!(_ type: DispatchIOType,
          io: DispatchIO,
          queue: DispatchQueue? = nil, cleanup: CleanupHandler! = nil) {
-        
+
         guard let rawValue = dispatch_io_create_with_io(type.rawValue, io.rawValue, queue?.rawValue, cleanup) else {
             return nil
         }
@@ -120,7 +120,7 @@ public struct DispatchIO: DispatchObject {
     public func setInterval(interval: Int64, flags: DispatchIOIntervalFlags = .Unspecified) {
         dispatch_io_set_interval(rawValue, UInt64(interval), flags.rawValue)
     }
-    
+
     public func barrier(block: dispatch_block_t) {
         dispatch_io_barrier(rawValue, block)
     }

--- a/Sources/DispatchIO.swift
+++ b/Sources/DispatchIO.swift
@@ -14,12 +14,12 @@ public struct DispatchIO: DispatchObject {
         return rawValue
     }
 
-    public let rawValue: dispatch_io_t
-
     @available(*, unavailable, renamed="DispatchIO(rawValue:)")
     public init(raw io: dispatch_io_t) {
         self.rawValue = io
     }
+
+    public let rawValue: dispatch_io_t
 
     public init(rawValue: dispatch_io_t) {
         self.rawValue = rawValue

--- a/Sources/DispatchIO.swift
+++ b/Sources/DispatchIO.swift
@@ -9,21 +9,19 @@ import Foundation
 
 public struct DispatchIO: DispatchObject {
 
-    public typealias RawValue = dispatch_io_t
-
     @available(*, unavailable, renamed="rawValue")
-    public var io: RawValue {
+    public var io: dispatch_io_t {
         return rawValue
     }
 
-    public let rawValue: RawValue
+    public let rawValue: dispatch_io_t
 
     @available(*, unavailable, renamed="DispatchIO(rawValue:)")
-    public init(raw io: RawValue) {
+    public init(raw io: dispatch_io_t) {
         self.rawValue = io
     }
 
-    public init(rawValue: RawValue) {
+    public init(rawValue: dispatch_io_t) {
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchIO.swift
+++ b/Sources/DispatchIO.swift
@@ -9,100 +9,120 @@ import Foundation
 
 public struct DispatchIO: DispatchObject {
 
-    public let io: dispatch_io_t!
-
-    public var rawValue: dispatch_object_t! {
-        return io
+    public typealias RawValue = dispatch_io_t
+    
+    @available(*, unavailable, renamed="rawValue")
+    public var io: RawValue {
+        return rawValue
     }
+    
+    public let rawValue: RawValue
 
-    public init(raw io: dispatch_io_t!) {
-        self.io = io
+    @available(*, unavailable, renamed="DispatchIO(rawValue:)")
+    public init(raw io: RawValue) {
+        self.rawValue = io
+    }
+    
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
     }
 
     public typealias CleanupHandler = (error: CInt) -> Void
 
-    public init(_ type: DispatchIOType,
+    public init!(_ type: DispatchIOType,
          fd: dispatch_fd_t,
          queue: DispatchQueue? = nil, cleanup: CleanupHandler! = nil) {
 
-        self.io = dispatch_io_create(type.rawValue, fd, queue?.queue, cleanup)
+        guard let rawValue = dispatch_io_create(type.rawValue, fd, queue?.rawValue, cleanup) else {
+            return nil
+        }
+        
+        self.rawValue = rawValue
     }
 
-    public init(_ type: DispatchIOType,
+    public init!(_ type: DispatchIOType,
          path: String, oflag: CInt = O_RDONLY, mode: mode_t = 0o644,
          queue: DispatchQueue? = nil, cleanup: CleanupHandler! = nil) {
+        
+        guard let rawValue = dispatch_io_create_with_path(type.rawValue, path, oflag, mode, queue?.rawValue, cleanup) else {
+            return nil
+        }
 
-        self.io = dispatch_io_create_with_path(type.rawValue, path, oflag, mode, queue?.queue, cleanup)
+        self.rawValue = rawValue
     }
 
-    public init(_ type: DispatchIOType,
+    public init!(_ type: DispatchIOType,
          io: DispatchIO,
          queue: DispatchQueue? = nil, cleanup: CleanupHandler! = nil) {
+        
+        guard let rawValue = dispatch_io_create_with_io(type.rawValue, io.rawValue, queue?.rawValue, cleanup) else {
+            return nil
+        }
 
-        self.io = dispatch_io_create_with_io(type.rawValue, io.io, queue?.queue, cleanup)
+        self.rawValue = rawValue
     }
 
 
     public static func read<T>(fd: dispatch_fd_t, length: Int = Int.max,
-                        queue: DispatchQueue, handler: (DispatchData<T>, Int) -> Void) {
+                        queue: DispatchQueue, handler: (DispatchData<T>!, Int) -> Void) {
 
-        dispatch_read(fd, length, queue.queue) {
+        dispatch_read(fd, length, queue.rawValue) {
             (data, error) in
-            handler(DispatchData<T>(raw: data), Int(error))
+            handler(DispatchData<T>(rawValue: data), Int(error))
         }
     }
 
     public static func write<T>(fd: dispatch_fd_t, data: DispatchData<T>,
-                         queue: DispatchQueue, handler: (DispatchData<T>, Int) -> Void) {
+                         queue: DispatchQueue, handler: (DispatchData<T>!, Int) -> Void) {
 
-        dispatch_write(fd, data.data, queue.queue) {
+        dispatch_write(fd, data.rawValue, queue.rawValue) {
             (data, error) in
-            handler(DispatchData<T>(raw: data), Int(error))
+            handler(DispatchData<T>(rawValue: data), Int(error))
         }
     }
 
 
     public func read<T>(offset: off_t = 0, length: Int = Int.max,
-                 queue: DispatchQueue, handler: (Bool, DispatchData<T>, Int) -> Void) {
+                 queue: DispatchQueue, handler: (Bool, DispatchData<T>!, Int) -> Void) {
 
-        dispatch_io_read(io, offset, length, queue.queue) {
+        dispatch_io_read(rawValue, offset, length, queue.rawValue) {
             (done, data, error) in
-            handler(done, DispatchData<T>(raw: data), Int(error))
+            handler(done, DispatchData<T>(rawValue: data), Int(error))
         }
     }
 
     public func write<T>(offset: off_t = 0, data: DispatchData<T>,
-                  queue: DispatchQueue, handler: (Bool, DispatchData<T>, Int) -> Void) {
+                  queue: DispatchQueue, handler: (Bool, DispatchData<T>!, Int) -> Void) {
 
-        dispatch_io_write(io, offset, data.data, queue.queue) {
+        dispatch_io_write(rawValue, offset, data.rawValue, queue.rawValue) {
             (done, data, error) in
-            handler(done, DispatchData<T>(raw: data), Int(error))
+            handler(done, DispatchData<T>(rawValue: data), Int(error))
         }
     }
 
 
     public func close(flags: DispatchIOCloseFlags = .Unspecified) {
-        dispatch_io_close(io, flags.rawValue)
+        dispatch_io_close(rawValue, flags.rawValue)
     }
 
     public var descriptior: dispatch_fd_t {
-        return dispatch_io_get_descriptor(io)
+        return dispatch_io_get_descriptor(rawValue)
     }
 
     public func setHighWater(highWater: Int) {
-        dispatch_io_set_high_water(io, highWater)
+        dispatch_io_set_high_water(rawValue, highWater)
     }
 
     public func setLowWater(lowWater: Int) {
-        dispatch_io_set_low_water(io, lowWater)
+        dispatch_io_set_low_water(rawValue, lowWater)
     }
 
     public func setInterval(interval: Int64, flags: DispatchIOIntervalFlags = .Unspecified) {
-        dispatch_io_set_interval(io, UInt64(interval), flags.rawValue)
+        dispatch_io_set_interval(rawValue, UInt64(interval), flags.rawValue)
     }
     
     public func barrier(block: dispatch_block_t) {
-        dispatch_io_barrier(io, block)
+        dispatch_io_barrier(rawValue, block)
     }
 
 }

--- a/Sources/DispatchIOConstants.swift
+++ b/Sources/DispatchIOConstants.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum DKDispatchIOType {
-    
+
     case Stream,
     Random
-    
+
     public var rawValue: dispatch_io_type_t {
         switch self {
         case .Stream:
@@ -20,35 +20,35 @@ public enum DKDispatchIOType {
             return DISPATCH_IO_RANDOM
         }
     }
-    
+
 }
 
 public struct DKDispatchIOCloseFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_io_close_flags_t
     public let rawValue: RawValue
     public init(rawValue: dispatch_io_close_flags_t) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchIOCloseFlags(rawValue: 0)
     public static let Stop = DKDispatchIOCloseFlags(rawValue: DISPATCH_IO_STOP)
-    
+
 }
 
 
 
 public struct DKDispatchIOIntervalFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_io_interval_flags_t
     public let rawValue: RawValue
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchIOIntervalFlags(rawValue: 0)
     public static let Strict = DKDispatchIOIntervalFlags(rawValue: DISPATCH_IO_STRICT_INTERVAL)
-    
+
 }
 
 public typealias DispatchIOType = DKDispatchIOType

--- a/Sources/DispatchObject.swift
+++ b/Sources/DispatchObject.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public protocol DispatchObject {
-    var rawValue: dispatch_object_t! { get }
+    typealias RawValue: dispatch_object_t
+    var rawValue: RawValue { get }
 }
 
 public protocol DispatchResumable {

--- a/Sources/DispatchObject.swift
+++ b/Sources/DispatchObject.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol DispatchObject {
+public protocol DispatchObject: RawRepresentable {
     typealias RawValue: dispatch_object_t
     var rawValue: RawValue { get }
 }

--- a/Sources/DispatchQueue.swift
+++ b/Sources/DispatchQueue.swift
@@ -9,17 +9,25 @@ import Foundation
 
 public struct DispatchQueue : DispatchObject, DispatchResumable {
     
-    public let queue: dispatch_queue_t!
-
-    public var rawValue: dispatch_object_t! {
-        return queue
+    public typealias RawValue = dispatch_queue_t
+    
+    @available(*, unavailable, renamed="rawValue")
+    public var queue: RawValue {
+        return rawValue
     }
 
-    public init(raw queue: dispatch_queue_t!) {
-        self.queue = queue
+    public let rawValue: RawValue
+
+    @available(*, unavailable, renamed="DispatchQueue(rawValue:)")
+    public init(raw queue: RawValue) {
+        self.rawValue = queue
+    }
+    
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
     }
 
-    public init(_ label: String! = nil,
+    public init!(_ label: String! = nil,
                 attr: DispatchQueueAttr = .Serial,
                 qosClass: DispatchQOSClass = .Unspecified,
                 relativePriority: Int = 0) {
@@ -27,33 +35,39 @@ public struct DispatchQueue : DispatchObject, DispatchResumable {
                "Invalid parameter: relative_priority")
 
         if qosClass == .Unspecified {
-            self.queue = dispatch_queue_create(label, attr.rawValue)
+            guard let rawValue = dispatch_queue_create(label, attr.rawValue) else {
+                return nil
+            }
+            
+            self.rawValue = rawValue
         } else if #available(iOS 8.0, *) {
             // iOS 8 and later: apply QOS class
-            if let qosAttr = dispatch_queue_attr_make_with_qos_class(
-                    attr.rawValue, qosClass.rawClass, Int32(relativePriority)) {
-                self.queue = dispatch_queue_create(label, qosAttr)
-            } else {
-                self.queue = nil
+            guard
+                let qosAttr = dispatch_queue_attr_make_with_qos_class(
+                    attr.rawValue, qosClass.rawClass, Int32(relativePriority)),
+                let rawValue = dispatch_queue_create(label, qosAttr)
+            else {
+                return nil
             }
+            
+            self.rawValue = rawValue
         } else {
-            self.queue = dispatch_queue_create(label, attr.rawValue)
+            guard let rawValue = dispatch_queue_create(label, attr.rawValue) else {
+                return nil
+            }
+            
+            self.rawValue = rawValue
 
             // iOS 7 and earlier: simulate QOS class by applying a target queue.
-            if let queue = self.queue {
-                let priority = DispatchQueuePriority(qosClass: qosClass)
-                let target = dispatch_get_global_queue(priority.rawValue, 0)
-                dispatch_set_target_queue(queue, target)
-            }
+            let priority = DispatchQueuePriority(qosClass: qosClass)
+            let target = dispatch_get_global_queue(priority.rawValue, 0)
+            dispatch_set_target_queue(rawValue, target)
         }
     }
 
     public var clabel: UnsafePointer<CChar> {
-        if queue != nil {
-            // this function never returns NULL, despite its documentation.
-            return dispatch_queue_get_label(queue)
-        }
-        return nil
+        // this function never returns NULL, despite its documentation.
+        return dispatch_queue_get_label(rawValue)
     }
 
     public var label: String {
@@ -77,49 +91,49 @@ public struct DispatchQueue : DispatchObject, DispatchResumable {
     // NOTE set to nil to reset target queue to default
     public func setTargetQueue(targetQueue: DispatchQueue?) {
         assert(!isSystemQueue)
-        dispatch_set_target_queue(queue, targetQueue?.queue)
+        dispatch_set_target_queue(rawValue, targetQueue?.rawValue)
     }
 
 
     public func suspend() {
-        dispatch_suspend(queue)
+        dispatch_suspend(rawValue)
     }
 
     public func resume() {
-        dispatch_resume(queue)
+        dispatch_resume(rawValue)
     }
 
 
     public func sync(block: dispatch_block_t) {
-        dispatch_sync(queue, block)
+        dispatch_sync(rawValue, block)
     }
 
     public func barrierSync(block: dispatch_block_t) {
         assert(!isSystemQueue)
-        dispatch_barrier_sync(queue, block)
+        dispatch_barrier_sync(rawValue, block)
     }
 
     public func apply(iterations: Int, block: (Int) -> Void) {
-        dispatch_apply(iterations, queue, { block($0) })
+        dispatch_apply(iterations, rawValue, { block($0) })
     }
 
 
     public func async(block: dispatch_block_t) {
-        dispatch_async(queue, block)
+        dispatch_async(rawValue, block)
     }
 
     public func async(group: DispatchGroup, block: dispatch_block_t) {
-        dispatch_group_async(group.group, queue, block)
+        dispatch_group_async(group.rawValue, rawValue, block)
     }
 
     public func barrierAsync(block: dispatch_block_t) {
         assert(!isSystemQueue)
-        dispatch_barrier_async(queue, block)
+        dispatch_barrier_async(rawValue, block)
     }
 
 
     public func after(when: DispatchTime, block: dispatch_block_t) {
-        dispatch_after(when.rawValue, queue, block)
+        dispatch_after(when.rawValue, rawValue, block)
     }
 
 }

--- a/Sources/DispatchQueue.swift
+++ b/Sources/DispatchQueue.swift
@@ -9,21 +9,19 @@ import Foundation
 
 public struct DispatchQueue : DispatchObject, DispatchResumable {
 
-    public typealias RawValue = dispatch_queue_t
-
     @available(*, unavailable, renamed="rawValue")
-    public var queue: RawValue {
+    public var queue: dispatch_queue_t {
         return rawValue
     }
 
-    public let rawValue: RawValue
+    public let rawValue: dispatch_queue_t
 
     @available(*, unavailable, renamed="DispatchQueue(rawValue:)")
-    public init(raw queue: RawValue) {
+    public init(raw queue: dispatch_queue_t) {
         self.rawValue = queue
     }
 
-    public init(rawValue: RawValue) {
+    public init(rawValue: dispatch_queue_t) {
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchQueue.swift
+++ b/Sources/DispatchQueue.swift
@@ -14,12 +14,12 @@ public struct DispatchQueue : DispatchObject, DispatchResumable {
         return rawValue
     }
 
-    public let rawValue: dispatch_queue_t
-
     @available(*, unavailable, renamed="DispatchQueue(rawValue:)")
     public init(raw queue: dispatch_queue_t) {
         self.rawValue = queue
     }
+
+    public let rawValue: dispatch_queue_t
 
     public init(rawValue: dispatch_queue_t) {
         self.rawValue = rawValue

--- a/Sources/DispatchQueue.swift
+++ b/Sources/DispatchQueue.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 public struct DispatchQueue : DispatchObject, DispatchResumable {
-    
+
     public typealias RawValue = dispatch_queue_t
-    
+
     @available(*, unavailable, renamed="rawValue")
     public var queue: RawValue {
         return rawValue
@@ -22,7 +22,7 @@ public struct DispatchQueue : DispatchObject, DispatchResumable {
     public init(raw queue: RawValue) {
         self.rawValue = queue
     }
-    
+
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
@@ -38,7 +38,7 @@ public struct DispatchQueue : DispatchObject, DispatchResumable {
             guard let rawValue = dispatch_queue_create(label, attr.rawValue) else {
                 return nil
             }
-            
+
             self.rawValue = rawValue
         } else if #available(iOS 8.0, *) {
             // iOS 8 and later: apply QOS class
@@ -49,13 +49,13 @@ public struct DispatchQueue : DispatchObject, DispatchResumable {
             else {
                 return nil
             }
-            
+
             self.rawValue = rawValue
         } else {
             guard let rawValue = dispatch_queue_create(label, attr.rawValue) else {
                 return nil
             }
-            
+
             self.rawValue = rawValue
 
             // iOS 7 and earlier: simulate QOS class by applying a target queue.

--- a/Sources/DispatchQueueConstants.swift
+++ b/Sources/DispatchQueueConstants.swift
@@ -22,7 +22,7 @@ public enum DispatchQueueAttr {
 }
 
 public enum DispatchQOSClass {
-    
+
     case Unspecified
     case UserInteractive
     case UserInitiated
@@ -113,5 +113,5 @@ public enum DispatchQueuePriority {
             return DISPATCH_QUEUE_PRIORITY_BACKGROUND
         }
     }
-    
+
 }

--- a/Sources/DispatchQueueSpecific.swift
+++ b/Sources/DispatchQueueSpecific.swift
@@ -9,12 +9,12 @@ import Foundation
 
 public extension DispatchQueue {
     public func getSpecific<T: AnyObject>(key: UnsafePointer<Void>) -> T? {
-        let specific = dispatch_queue_get_specific(queue, key)
+        let specific = dispatch_queue_get_specific(rawValue, key)
         return dk_takeUnretained(specific)
     }
 
     public func setSpecific<T: AnyObject>(key: UnsafePointer<Void>, _ specific: T?) {
-        dispatch_queue_set_specific(queue, key, dk_passRetained(specific), dk_release)
+        dispatch_queue_set_specific(rawValue, key, dk_passRetained(specific), dk_release)
     }
 }
 

--- a/Sources/DispatchSemaphore.swift
+++ b/Sources/DispatchSemaphore.swift
@@ -24,6 +24,10 @@ public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
         self.rawValue = semaphore
     }
 
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+
     public init!(_ value: Int) {
         assert(0 <= value)
 

--- a/Sources/DispatchSemaphore.swift
+++ b/Sources/DispatchSemaphore.swift
@@ -14,13 +14,12 @@ public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
         return rawValue
     }
 
-    public let rawValue: dispatch_semaphore_t
-
-
     @available(*, unavailable, renamed="DispatchSemaphore(rawValue:)")
     public init(raw semaphore: dispatch_semaphore_t) {
         self.rawValue = semaphore
     }
+
+    public let rawValue: dispatch_semaphore_t
 
     public init(rawValue: dispatch_semaphore_t) {
         self.rawValue = rawValue

--- a/Sources/DispatchSemaphore.swift
+++ b/Sources/DispatchSemaphore.swift
@@ -8,20 +8,30 @@
 import Foundation
 
 public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
+    
+    public typealias RawValue = dispatch_semaphore_t
 
-    public let semaphore: dispatch_semaphore_t!
+    @available(*, unavailable, renamed="rawValue")
+    public var semaphore: RawValue {
+        return rawValue
+    }
+    
+    public let rawValue: RawValue
 
-    public var rawValue: dispatch_object_t! {
-        return semaphore
+    
+    @available(*, unavailable, renamed="DispatchSemaphore(rawValue:)")
+    public init(raw semaphore: RawValue) {
+        self.rawValue = semaphore
     }
 
-    public init(raw semaphore: dispatch_semaphore_t!) {
-        self.semaphore = semaphore
-    }
-
-    public init(_ value: Int) {
+    public init!(_ value: Int) {
         assert(0 <= value)
-        self.semaphore = dispatch_semaphore_create(value)
+        
+        guard let rawValue = dispatch_semaphore_create(value) else {
+            return nil
+        }
+        
+        self.rawValue = rawValue
     }
 
 
@@ -31,11 +41,11 @@ public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
     }
 
     public func wait(timeout: DispatchTime) -> Int {
-        return dispatch_semaphore_wait(semaphore, timeout.rawValue)
+        return dispatch_semaphore_wait(rawValue, timeout.rawValue)
     }
 
     public func signal() -> Int {
-        return dispatch_semaphore_signal(semaphore)
+        return dispatch_semaphore_signal(rawValue)
     }
 
 }

--- a/Sources/DispatchSemaphore.swift
+++ b/Sources/DispatchSemaphore.swift
@@ -8,17 +8,17 @@
 import Foundation
 
 public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
-    
+
     public typealias RawValue = dispatch_semaphore_t
 
     @available(*, unavailable, renamed="rawValue")
     public var semaphore: RawValue {
         return rawValue
     }
-    
+
     public let rawValue: RawValue
 
-    
+
     @available(*, unavailable, renamed="DispatchSemaphore(rawValue:)")
     public init(raw semaphore: RawValue) {
         self.rawValue = semaphore
@@ -26,11 +26,11 @@ public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
 
     public init!(_ value: Int) {
         assert(0 <= value)
-        
+
         guard let rawValue = dispatch_semaphore_create(value) else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchSemaphore.swift
+++ b/Sources/DispatchSemaphore.swift
@@ -9,22 +9,20 @@ import Foundation
 
 public struct DispatchSemaphore: DispatchObject, DispatchWaitable {
 
-    public typealias RawValue = dispatch_semaphore_t
-
     @available(*, unavailable, renamed="rawValue")
-    public var semaphore: RawValue {
+    public var semaphore: dispatch_semaphore_t {
         return rawValue
     }
 
-    public let rawValue: RawValue
+    public let rawValue: dispatch_semaphore_t
 
 
     @available(*, unavailable, renamed="DispatchSemaphore(rawValue:)")
-    public init(raw semaphore: RawValue) {
+    public init(raw semaphore: dispatch_semaphore_t) {
         self.rawValue = semaphore
     }
 
-    public init(rawValue: RawValue) {
+    public init(rawValue: dispatch_semaphore_t) {
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchSource.swift
+++ b/Sources/DispatchSource.swift
@@ -8,71 +8,79 @@
 import Foundation
 
 public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancelable {
+    
+    public typealias RawValue = dispatch_source_t
 
-    public let source: dispatch_source_t!
-
-    public var rawValue: dispatch_object_t! {
-        return source
+    @available(*, unavailable, renamed="rawValue")
+    public var source: RawValue {
+        return rawValue
     }
 
+    public let rawValue: RawValue
+    
+    @available(*, unavailable, renamed="DispatchSource(rawValue:)")
     public init(raw source: dispatch_source_t!) {
-        self.source = source
+        self.rawValue = source
     }
 
-    public init(_ type: DispatchSourceType, handle: UInt = 0, mask: UInt = 0, queue: DispatchQueue) {
-        self.source = dispatch_source_create(type.toOpaque(), handle, mask, queue.queue)
+    public init!(_ type: DispatchSourceType, handle: UInt = 0, mask: UInt = 0, queue: DispatchQueue) {
+        guard let rawValue = dispatch_source_create(type.toOpaque(), handle, mask, queue.rawValue) else {
+            return nil
+        }
+        
+        self.rawValue = rawValue
     }
 
 
     public func suspend() {
-        dispatch_suspend(source)
+        dispatch_suspend(rawValue)
     }
 
     public func resume() {
-        dispatch_resume(source)
+        dispatch_resume(rawValue)
     }
 
 
     public func setRegistrationHandler(handler: dispatch_block_t!) {
-        dispatch_source_set_registration_handler(source, handler)
+        dispatch_source_set_registration_handler(rawValue, handler)
     }
 
     public func setEventHandler(handler: dispatch_block_t!) {
-        dispatch_source_set_event_handler(source, handler)
+        dispatch_source_set_event_handler(rawValue, handler)
     }
 
     public func setCancelHandler(handler: dispatch_block_t!) {
-        dispatch_source_set_cancel_handler(source, handler)
+        dispatch_source_set_cancel_handler(rawValue, handler)
     }
 
 
     public func cancel() {
-        dispatch_source_cancel(source)
+        dispatch_source_cancel(rawValue)
     }
 
     public func testCancel() -> Bool {
-        return 0 != dispatch_source_testcancel(source)
+        return 0 != dispatch_source_testcancel(rawValue)
     }
 
 
     public var handle: Int {
-        return Int(bitPattern: dispatch_source_get_handle(source))
+        return Int(bitPattern: dispatch_source_get_handle(rawValue))
     }
 
     public var mask: UInt {
-        return dispatch_source_get_mask(source)
+        return dispatch_source_get_mask(rawValue)
     }
 
     public var data: Int {
-        return Int(bitPattern: dispatch_source_get_data(source))
+        return Int(bitPattern: dispatch_source_get_data(rawValue))
     }
 
     public func mergeData(value: Int) {
-        dispatch_source_merge_data(source, UInt(value))
+        dispatch_source_merge_data(rawValue, UInt(value))
     }
 
     public func setTimer(start: DispatchTime, interval: DispatchTimeDelta, leeway: DispatchTimeDelta) {
-        dispatch_source_set_timer(source, start.rawValue, interval.rawValue, leeway.rawValue)
+        dispatch_source_set_timer(rawValue, start.rawValue, interval.rawValue, leeway.rawValue)
     }
 
 }

--- a/Sources/DispatchSource.swift
+++ b/Sources/DispatchSource.swift
@@ -14,12 +14,12 @@ public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancela
         return rawValue
     }
 
-    public let rawValue: dispatch_source_t
-
     @available(*, unavailable, renamed="DispatchSource(rawValue:)")
     public init(raw source: dispatch_source_t!) {
         self.rawValue = source
     }
+
+    public let rawValue: dispatch_source_t
 
     public init(rawValue: dispatch_source_t) {
         self.rawValue = rawValue

--- a/Sources/DispatchSource.swift
+++ b/Sources/DispatchSource.swift
@@ -23,6 +23,10 @@ public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancela
         self.rawValue = source
     }
 
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+
     public init!(_ type: DispatchSourceType, handle: UInt = 0, mask: UInt = 0, queue: DispatchQueue) {
         guard let rawValue = dispatch_source_create(type.toOpaque(), handle, mask, queue.rawValue) else {
             return nil

--- a/Sources/DispatchSource.swift
+++ b/Sources/DispatchSource.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancelable {
-    
+
     public typealias RawValue = dispatch_source_t
 
     @available(*, unavailable, renamed="rawValue")
@@ -17,7 +17,7 @@ public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancela
     }
 
     public let rawValue: RawValue
-    
+
     @available(*, unavailable, renamed="DispatchSource(rawValue:)")
     public init(raw source: dispatch_source_t!) {
         self.rawValue = source
@@ -27,7 +27,7 @@ public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancela
         guard let rawValue = dispatch_source_create(type.toOpaque(), handle, mask, queue.rawValue) else {
             return nil
         }
-        
+
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchSource.swift
+++ b/Sources/DispatchSource.swift
@@ -9,21 +9,19 @@ import Foundation
 
 public struct DispatchSource: DispatchObject, DispatchResumable, DispatchCancelable {
 
-    public typealias RawValue = dispatch_source_t
-
     @available(*, unavailable, renamed="rawValue")
-    public var source: RawValue {
+    public var source: dispatch_source_t {
         return rawValue
     }
 
-    public let rawValue: RawValue
+    public let rawValue: dispatch_source_t
 
     @available(*, unavailable, renamed="DispatchSource(rawValue:)")
     public init(raw source: dispatch_source_t!) {
         self.rawValue = source
     }
 
-    public init(rawValue: RawValue) {
+    public init(rawValue: dispatch_source_t) {
         self.rawValue = rawValue
     }
 

--- a/Sources/DispatchSourceConstants.swift
+++ b/Sources/DispatchSourceConstants.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum DKDispatchSourceType: UInt {
-    
+
     case Unspecified = 0,
     DataAdd,
     DataOr,
@@ -21,61 +21,61 @@ public enum DKDispatchSourceType: UInt {
     VNode,
     Write,
     MemoryPressure
-    
+
 }
 
 public struct DKDispatchSourceMachSendFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_source_mach_send_flags_t
     public let rawValue: RawValue
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchSourceMachSendFlags(rawValue: 0)
     public static let Dead = DKDispatchSourceMachSendFlags(rawValue: DISPATCH_MACH_SEND_DEAD)
-    
+
 }
 
 public struct DKDispatchSourceMemoryPressureFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_source_memorypressure_flags_t
     public let rawValue: RawValue
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchSourceMemoryPressureFlags(rawValue: 0)
     public static let Normal = DKDispatchSourceMemoryPressureFlags(rawValue: DISPATCH_MEMORYPRESSURE_NORMAL)
     public static let Warn = DKDispatchSourceMemoryPressureFlags(rawValue: DISPATCH_MEMORYPRESSURE_WARN)
     public static let Critical = DKDispatchSourceMemoryPressureFlags(rawValue: DISPATCH_MEMORYPRESSURE_CRITICAL)
-    
+
 }
 
 public struct DKDispatchSourceProcFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_source_proc_flags_t
     public let rawValue: RawValue
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchSourceProcFlags(rawValue: 0)
     public static let Exit = DKDispatchSourceProcFlags(rawValue: DISPATCH_PROC_EXIT)
     public static let Fork = DKDispatchSourceProcFlags(rawValue: DISPATCH_PROC_FORK)
     public static let Exec = DKDispatchSourceProcFlags(rawValue: DISPATCH_PROC_EXEC)
     public static let Signal = DKDispatchSourceProcFlags(rawValue: DISPATCH_PROC_SIGNAL)
-    
+
 }
 
 public struct DKDispatchSourceVnodeFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_source_vnode_flags_t
     public let rawValue: RawValue
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchSourceVnodeFlags(rawValue: 0)
     public static let Delete = DKDispatchSourceVnodeFlags(rawValue: DISPATCH_VNODE_DELETE)
     public static let Write = DKDispatchSourceVnodeFlags(rawValue: DISPATCH_VNODE_WRITE)
@@ -84,26 +84,26 @@ public struct DKDispatchSourceVnodeFlags: OptionSetType {
     public static let Link = DKDispatchSourceVnodeFlags(rawValue: DISPATCH_VNODE_LINK)
     public static let Rename = DKDispatchSourceVnodeFlags(rawValue: DISPATCH_VNODE_RENAME)
     public static let Revoke = DKDispatchSourceVnodeFlags(rawValue: DISPATCH_VNODE_REVOKE)
-    
+
 }
 
 public struct DKDispatchSourceTimerFlags: OptionSetType {
-    
+
     public typealias RawValue = dispatch_source_timer_flags_t
     public let rawValue: RawValue
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
     public static let Unspecified = DKDispatchSourceTimerFlags(rawValue: 0)
     public static let Strict = DKDispatchSourceTimerFlags(rawValue: DISPATCH_TIMER_STRICT)
-    
+
 }
 
 public typealias DispatchSourceType = DKDispatchSourceType
 
 extension DispatchSourceType {
-    
+
     public func toOpaque() -> dispatch_source_type_t {
         switch (self) {
         case .Unspecified:
@@ -132,7 +132,7 @@ extension DispatchSourceType {
             return DISPATCH_SOURCE_TYPE_MEMORYPRESSURE
         }
     }
-    
+
 }
 
 public typealias DispatchSourceMachSendFlags = DKDispatchSourceMachSendFlags

--- a/Tests/DispatchDataTests.swift
+++ b/Tests/DispatchDataTests.swift
@@ -48,13 +48,13 @@ class DispatchDataTests: XCTestCase {
             (region, buffer) -> Bool in
             switch i {
             case 0xA:
-                XCTAssert(self.a.data === region.data.data)
+                XCTAssert(self.a.rawValue === region.data.rawValue)
                 XCTAssertEqual(0, region.offset)
                 XCTAssertEqual(2, buffer.count)
                 XCTAssertEqual(13, buffer.start[0])
                 XCTAssertEqual(14, buffer.start[1])
             case 0xB:
-                XCTAssert(self.b.data === region.data.data)
+                XCTAssert(self.b.rawValue === region.data.rawValue)
                 XCTAssertEqual(2, region.offset)
                 XCTAssertEqual(3, buffer.count)
                 XCTAssertEqual(15, buffer.start[0])

--- a/Tests/DispatchSemaphoreTests.swift
+++ b/Tests/DispatchSemaphoreTests.swift
@@ -13,7 +13,7 @@ class DispatchSemaphoreTests: XCTestCase {
     let foo = DispatchSemaphore(1)
 
     func test1() {
-        
+
     }
 
 }

--- a/Tests/DispatchTests.swift
+++ b/Tests/DispatchTests.swift
@@ -11,12 +11,12 @@ import XCTest
 class DispatchTests: XCTestCase {
 
     func testMainQueue() {
-        XCTAssert(dispatch_get_main_queue() === Dispatch.mainQueue.queue)
+        XCTAssert(dispatch_get_main_queue() === Dispatch.mainQueue.rawValue)
     }
 
     func testGlobalQueue() {
         XCTAssert(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) ===
-            Dispatch.globalQueue.queue)
+            Dispatch.globalQueue.rawValue)
     }
 
 }

--- a/Tools/strip-trailing-whitespace
+++ b/Tools/strip-trailing-whitespace
@@ -1,0 +1,30 @@
+#!/usr/bin/perl -w
+
+use strict;
+use File::Find qw(find);
+
+find sub {
+  if (-d) {
+    $File::Find::prune = 1 if /^\.(git|hg|svn)$/;
+    return;
+  }
+  return unless /\.swift$/;
+
+  my $file = $_;
+  my $changes = 0;
+  {
+    open my $input, "<$file" or die;
+    open my $output, ">$file.new" or die;
+    while (<$input>) {
+      $changes += s/\s+$//;
+      $changes += s/$(?!\n)/\n/;
+      print $output $_;
+    }
+  }
+
+  if (!$changes) {
+    unlink("$file.new");
+  } else {
+    rename("$file.new", "$file");
+  }
+}, ".";


### PR DESCRIPTION
Closes #7 - Deprecated various initializers and dispatch_object_t properties.

The list of classes below have all been modified in the same way. Each of them had one initializer init(raw:), and initialized the class by assigning its dispatch_object_t subtype property to raw. These initializers have been renamed to init(rawValue:). This is because DispatchObject now requires a get-able property named rawValue whose type is a subtype of dispatch_object_t. These classes each had a property which represented what is now called rawValue. The old properties and initializers have been deprecated in favor of the new ones.

Other initializers have also been modified to be failable (implicitly unwrapped), due to the fact that they would call dispatch_create_X functions which returned implicitly unwrapped optionals. Having failable initializers allows for the ease of use that is expected when these functions are expected not to fail, along with the added ability to handle failure should it occur.
- DispatchData
- DispatchGroup
- DispatchIO
- DispatchQueue
- DispatchSemaphore
- DispatchSource
